### PR TITLE
Update catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -13,6 +13,9 @@ metadata:
     - url: https://api.heroes.com
       title: Production
       icon: globe
+  annotations:
+    # this could also be `url:<url>` if the documentation isn't in the same location
+    backstage.io/techdocs-ref: dir:.
 spec:
   type: service
   lifecycle: production


### PR DESCRIPTION
This pull request includes a change to the `catalog-info.yaml` file. The change adds annotations to the metadata, specifically the `backstage.io/techdocs-ref` annotation, which indicates the location of the technical documentation for the service.