### PR TITLE
chore: Update node version to '18' in techdocs workflow

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '18'
       - run: npm install -g @techdocs/cli
       - run: |
             techdocs/cli generate --no-docker --source-dir docs --verbose


### PR DESCRIPTION
This pull request includes a change in the `.github/workflows/techdocs.yml` file where the `node-version` used in the GitHub Actions workflow has been updated from '14' to '18'. This change ensures that the latest Node.js version is used for the TechDocs CLI.