### PR TITLE
chore: Update techdocs CLI command and dependencies in techdocs.yml w…

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -32,7 +32,9 @@ jobs:
         run: techdocs-cli generate --no-docker --verbose
       - name: Publish documentation on Azure Blob Storage
         run: |
-          techdocs-cli publish --publisher-type azureBlobStorage \
+          techdocs-cli publish \
+          --entity $ENTITY_NAMESPACE/$ENTITY_KIND/$ENTITY_NAME \
+          --publisher-type azureBlobStorage \
           --azureAccountName ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }} \
           --azureAccountKey ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }} \
           --storage-name ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }} \


### PR DESCRIPTION
This pull request includes a change to the `techdocs.yml` file in the `.github/workflows` directory. The change modifies the command used to publish documentation on Azure Blob Storage in the `jobs:` section. Specifically, it adds an `--entity` flag to the `techdocs-cli publish` command, which specifies the namespace, kind, and name of the entity to be published. This change will provide more granularity and control over the publishing process.