### PR TITLE
chore: Update techdocs CLI command and dependencies in techdocs.yml w…

### DIFF
--- a/.github/workflows/techdocs.yml
+++ b/.github/workflows/techdocs.yml
@@ -37,5 +37,4 @@ jobs:
           --publisher-type azureBlobStorage \
           --azureAccountName ${{ secrets.AZURE_STORAGE_ACCOUNT_NAME }} \
           --azureAccountKey ${{ secrets.AZURE_STORAGE_ACCOUNT_KEY }} \
-          --storage-name ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }} \
-          --verbose
+          --storage-name ${{ secrets.AZURE_STORAGE_CONTAINER_NAME }}


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/techdocs.yml` file. The change removes the `--verbose` flag from the command that runs the techdocs job, which means the job's logs will no longer include detailed output. This could potentially make it harder to debug issues with the job, but it will also reduce the amount of log output, which can make it easier to identify important messages in the logs.