### PR TITLE
Update Docker scan workflows to use the correct Dockerfile path 🐳

### DIFF
--- a/.github/workflows/docker-scans.yml
+++ b/.github/workflows/docker-scans.yml
@@ -16,7 +16,7 @@ jobs:
       security-events: write
     uses: 0GiS0/scan-docker-vulnerabilities/.github/workflows/checkov.yaml@main
     with:
-      dockerfile_path: src/Dockerfile
+      dockerfile_path: build/docker/Dockerfile
 
   trivy:
     permissions:
@@ -24,7 +24,7 @@ jobs:
       security-events: write
     uses: 0GiS0/scan-docker-vulnerabilities/.github/workflows/trivy.yaml@main
     with:
-      dockerfile_path: src/Dockerfile
+      dockerfile_path: build/docker/Dockerfile
       context: ./src  
 
   grype:
@@ -33,7 +33,7 @@ jobs:
       security-events: write
     uses: 0GiS0/scan-docker-vulnerabilities/.github/workflows/grype.yaml@main
     with:
-      dockerfile_path: src/Dockerfile
+      dockerfile_path: build/docker/Dockerfile
       context: ./src
 
   snyk:
@@ -42,7 +42,7 @@ jobs:
       security-events: write
     uses: 0GiS0/scan-docker-vulnerabilities/.github/workflows/snyk.yaml@main
     with:
-      dockerfile_path: src/Dockerfile
+      dockerfile_path: build/docker/Dockerfile
       context: ./src
 
     secrets:


### PR DESCRIPTION
Dockerfile path updates:

* [`.github/workflows/docker-scans.yml`](diffhunk://#diff-6902603380a039f9669a8a2ec06cdfd186433146ee5671f42fbbccc4f62f1d1cL19-R27): Updated the `dockerfile_path` for `checkov`, `trivy`, `grype`, and `snyk` jobs from `src/Dockerfile` to `build/docker/Dockerfile`. [[1]](diffhunk://#diff-6902603380a039f9669a8a2ec06cdfd186433146ee5671f42fbbccc4f62f1d1cL19-R27) [[2]](diffhunk://#diff-6902603380a039f9669a8a2ec06cdfd186433146ee5671f42fbbccc4f62f1d1cL36-R36) [[3]](diffhunk://#diff-6902603380a039f9669a8a2ec06cdfd186433146ee5671f42fbbccc4f62f1d1cL45-R45)