### PR TITLE
chore: 🔄 actualizar GitHub Actions a últimas versiones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: 🔧 Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 9.x
 
@@ -39,14 +39,14 @@ jobs:
         run: dotnet test --no-build --configuration Release --collect:"XPlat Code Coverage" --verbosity normal
 
       - name: 📊 Generate coverage report
-        uses: danielpalme/ReportGenerator-GitHub-Action@5.4.5
+        uses: danielpalme/ReportGenerator-GitHub-Action@5.5.1
         with:
           reports: "tests/TestResults/**/coverage.cobertura.xml"
           targetdir: "coveragereport"
           reporttypes: "MarkdownSummaryGithub;Badges"
 
       - name: 📤 Upload coverage report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: CoverageReport
           path: coveragereport


### PR DESCRIPTION
## 📋 Descripción

Actualiza todas las GitHub Actions del workflow de CI a sus últimas versiones disponibles.

## 🔄 Cambios

| Action | Antes | Después |
|--------|-------|---------|
| `actions/checkout` | v5 | **v6** |
| `actions/setup-dotnet` | v4 | **v5** |
| `actions/upload-artifact` | v4 | **v6** |
| `danielpalme/ReportGenerator-GitHub-Action` | 5.4.5 | **5.5.1** |

## ✅ Beneficios

- 🔒 Mejoras de seguridad (Node.js 24)
- 🚀 Mejor rendimiento
- 🐛 Corrección de bugs
- ✨ Nuevas características

## ⚠️ Notas

Las nuevas versiones requieren GitHub Actions Runner v2.327.1 o superior (los runners de GitHub ya lo tienen).

Closes #136