### PR TITLE
feat: 🗄️ añadir soporte para PostgreSQL via DATABASE_PROVIDER

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -23,6 +23,25 @@ services:
     networks:
       - observability
 
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: heroes
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    networks:
+      - observability
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:
@@ -99,3 +118,6 @@ services:
 
 networks:
   observability:
+
+volumes:
+  postgres-data:

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Tour of heroes API",
+	"name": "🦸 Tour of Heroes API ⚔️ | .NET 9 + PostgreSQL + OpenTelemetry 🚀",
 	"dockerComposeFile": "compose.yml",
 	"service": "app",
 	"workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
@@ -25,6 +25,7 @@
 				"ms-dotnettools.csharp",
 				"ms-dotnettools.csdevkit",
 				"ms-mssql.mssql",
+				"ckolkman.vscode-postgres",
 				"humao.rest-client",
 				"hashicorp.terraform",
 				"ms-azuretools.vscode-docker",
@@ -41,6 +42,7 @@
 	},
 	"forwardPorts": [
 		5020,
+		5432,
 		16686,
 		9090,
 		3000
@@ -48,18 +50,21 @@
 	"portsAttributes": {
 		"5020": {
 			"protocol": "http",
-			"label": "Tour of Heroes API"
+			"label": "🦸 Tour of Heroes API"
+		},
+		"5432": {
+			"label": "🐘 PostgreSQL"
 		},
 		"16686": {
 			"protocol": "http",
-			"label": "Jaeger UI"
+			"label": "🔍 Jaeger Tracing"
 		},
 		"9090": {
-			"label": "Prometheus",
+			"label": "📊 Prometheus Metrics",
 			"protocol": "http"
 		},
 		"3000": {
-			"label": "Grafana",
+			"label": "📈 Grafana Dashboards",
 			"protocol": "http"
 		}
 	},

--- a/src/appsettings.Development.json
+++ b/src/appsettings.Development.json
@@ -1,6 +1,8 @@
 {
+  "DATABASE_PROVIDER": "PostgreSQL",
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost,1433;Initial Catalog=heroes;Persist Security Info=False;User ID=sa;Password=Password1!;Encrypt=False"
+    "DefaultConnection": "Server=db,1433;Initial Catalog=heroes;Persist Security Info=False;User ID=sa;Password=P@ssword;Encrypt=False",
+    "PostgreSQL": "Host=postgres;Port=5432;Database=heroes;Username=postgres;Password=postgres"
   },
   "Logging": {
     "LogLevel": {

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -1,6 +1,8 @@
 {
+  "DATABASE_PROVIDER": "SqlServer",
   "ConnectionStrings": {
-    "DefaultConnection": "<SQL SERVER CONNECTION STRING>"
+    "DefaultConnection": "<SQL SERVER CONNECTION STRING>",
+    "PostgreSQL": "<POSTGRESQL CONNECTION STRING>"
   },
   "Logging": {
     "LogLevel": {

--- a/src/tour-of-heroes-api.csproj
+++ b/src/tour-of-heroes-api.csproj
@@ -15,6 +15,7 @@
 
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="9.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.12" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
 
     <!-- OpenTelemetry -->


### PR DESCRIPTION
**Database support and configuration:**

* Added conditional database provider logic in `Program.cs` to select between SQL Server and PostgreSQL based on the `DATABASE_PROVIDER` environment variable, and updated dependency injection to support both providers.
* Updated `appsettings.Development.json` and `appsettings.json` to include a `DATABASE_PROVIDER` setting and connection strings for both SQL Server and PostgreSQL. [[1]](diffhunk://#diff-fb80194725a02795a4b19c43b9d6f678ff28c7430c8bf54097830ec9b0602ce9R2-R5) [[2]](diffhunk://#diff-4f3092c803fde3de70bbd69d14f1156cf031d668c8696dcdaa21c83eb0aaa04cR2-R5)
* Added the `Npgsql.EntityFrameworkCore.PostgreSQL` package to the project for PostgreSQL support.

**Development environment enhancements:**

* Added a `postgres` service to `.devcontainer/compose.yml` with persistent storage, health checks, and network configuration, and defined a `postgres-data` volume. [[1]](diffhunk://#diff-85dc84cf35cfe2518db19af9c6e123046c01aa36bbe707e6ce5d469ea9dd1d43R26-R44) [[2]](diffhunk://#diff-85dc84cf35cfe2518db19af9c6e123046c01aa36bbe707e6ce5d469ea9dd1d43R121-R123)
* Improved the devcontainer setup: updated the display name to reflect PostgreSQL support, added the VSCode PostgreSQL extension, forwarded port 5432, and enhanced port labels for clarity and usability. [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L2-R2) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R28) [[3]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686R45-R67)