### PR TITLE
fix: 🔧 actualizar workflow de release a .NET 9

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,59 @@
-name: 📦 Generate .NET release
+name: 📦 Generate .NET Release
 
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+*" 
+      - "v[0-9]+.[0-9]+.[0-9]+*"
+
+permissions:
+  contents: write
+
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: dotnet restore
-      - run: dotnet build --configuration Release
-      - run: ls -la
-      - name: Zip dist
-        run: cd bin/Release/net7.0/ ; zip -r ../../../drop.zip . * ; cd ../../../
-      - name: Check package version
-        uses: technote-space/package-version-check-action@v1
-      - name: Build changelog
+      - name: 📥 Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: 🔧 Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 9.x
+
+      - name: 📦 Restore dependencies
+        run: dotnet restore
+        working-directory: src
+
+      - name: 🏗️ Build Release
+        run: dotnet build --configuration Release --no-restore
+        working-directory: src
+
+      - name: 🧪 Run tests
+        run: dotnet test --configuration Release --no-build
+        working-directory: tests
+
+      - name: 📁 Create release artifact
+        run: |
+          cd src/bin/Release/net9.0/
+          zip -r ../../../../tour-of-heroes-api.zip .
+        
+      - name: 📝 Build changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@main
+        uses: mikepenz/release-changelog-builder-action@v5
         with:
           configuration: "release-changelog-builder-config.json"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@latest
+
+      - name: 🚀 Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ github.ref_name }}
+          body: ${{ steps.build_changelog.outputs.changelog }}
+          draft: false
+          prerelease: ${{ contains(github.ref_name, '-') }}
+          files: tour-of-heroes-api.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body: ${{steps.build_changelog.outputs.changelog}}
-          draft: false
-          prerelease: false
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@v1
-        env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./drop.zip
-          asset_name: "drop.zip"
-          asset_content_type: application/zip


### PR DESCRIPTION
## 📋 Descripción

Actualiza el workflow de release que estaba obsoleto y no funcionaba.

## 🔄 Cambios

| Antes | Después |
|-------|---------|
| net7.0 | **net9.0** |
| actions/checkout@v4 | **actions/checkout@v6** |
| actions/create-release@latest (deprecada) | **softprops/action-gh-release@v2** |
| actions/upload-release-asset@v1 (deprecada) | (incluido en gh-release) |
| Sin setup-dotnet | **actions/setup-dotnet@v5** |
| Sin tests | **✅ Tests antes de release** |
| Tags: `1.0.0` | **Tags: `v1.0.0`** |

## ✨ Mejoras

- 🧪 Ejecuta tests antes de crear la release
- 🏷️ Detecta automáticamente prereleases (tags con `-`, ej: `v1.0.0-beta`)
- 📁 Working directories correctos
- 🎨 Emojis en todos los steps

## 📝 Cómo crear una release

```bash
# Release estable
git tag v1.0.0
git push origin v1.0.0

# Pre-release (beta, rc, etc.)
git tag v1.1.0-beta.1
git push origin v1.1.0-beta.1
```